### PR TITLE
Revise websocket endpoint to work with RubinTV v3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,11 +31,14 @@ jobs:
       - name: Install prereqs for setuptools
         run: pip install wheel
 
-      # We have two cores so we can speed up the testing with xdist
-      - name: Install xdist, openfiles and flake8 for pytest
+      # We have two cores so we can speed up the testing with xdist.
+      # pytest-flake8 is deliberately absent: it is unmaintained and fails to
+      # load under pytest 8+, and flake8 is already run by the lint workflow
+      # and the pre-commit hook.
+      - name: Install xdist, openfiles and coverage for pytest
         run: >
-          pip install pytest-xdist pytest-openfiles pytest-flake8
-          pytest-cov "flake8<5" setuptools
+          pip install pytest-xdist pytest-openfiles
+          pytest-cov setuptools
 
       - name: Build and install
         run: pip install -v -e .

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ pytest_session.txt
 .cache/
 .pytest_cache
 .coverage
+coverage.xml
 # result of running tests
 .logs/
 

--- a/doc/lsst.rubintv.analysis.service/deployment.rst
+++ b/doc/lsst.rubintv.analysis.service/deployment.rst
@@ -88,6 +88,50 @@ path — therefore has to be set in ``RUN_ARG`` for whichever instance departs
 from the default, and a change to a default must be checked against *every*
 pod on the branch, not just the one being worked on.
 
+Keeping the deploy branches up to date
+--------------------------------------
+
+Ordinary work goes to ``main`` through a PR as usual. A merged PR changes
+nothing at any site: the pods track deploy branches, so **a site only gets a
+change when its deploy branch does**.
+
+Once a change is reviewed and merged to ``main``, bring the deploy branches
+forward with::
+
+   scripts/update_deploy_branches.sh              # dry run: what each would take
+   scripts/update_deploy_branches.sh --push       # merge main in and push
+   scripts/update_deploy_branches.sh --push deploy-slac   # one site only
+
+Updating one site at a time is often the right call — it lets a change soak at
+USDF before it reaches the summit.
+
+Merge, don't rebase
+~~~~~~~~~~~~~~~~~~~
+
+The deploy branches are published and are pulled by running pods, so their
+history must not be rewritten: a pod that cloned mid-rebase would be sitting on
+a commit that no longer exists. The script merges for this reason, and the same
+applies to any manual update.
+
+Site-only commits
+~~~~~~~~~~~~~~~~~
+
+A deploy branch may carry commits that must never reach ``main`` — a site's
+database host, or a ``--path`` default that suits one web app version. Merging
+``main`` in preserves them; rebasing or force-pushing would not.
+
+This also means a deploy branch is **not** a staging area for changes headed to
+``main``. Anything of general value belongs in a PR against ``main``, or it
+will be lost the next time someone reconciles the branches.
+
+Stale branches
+~~~~~~~~~~~~~~
+
+``origin`` also carries ``deploy-usdf`` and ``deploy-slac-comcam``, which are
+predecessors and are **not** deployed. The script skips them deliberately.
+Check a branch is live — that some pod's ``DEPLOY_BRANCH`` names it — before
+updating it.
+
 Mounted paths
 -------------
 

--- a/doc/lsst.rubintv.analysis.service/deployment.rst
+++ b/doc/lsst.rubintv.analysis.service/deployment.rst
@@ -81,6 +81,13 @@ next restart. The deploy branches are:
 - ``deploy-summit`` — summit
 - ``deploy-bts`` — base test stand
 
+A branch is **not** one pod. USDF runs two instances against different
+endpoints, both tracking ``deploy-slac``, so a push reaches both on their next
+restart. Anything that differs between instances — notably the web app endpoint
+path — therefore has to be set in ``RUN_ARG`` for whichever instance departs
+from the default, and a change to a default must be checked against *every*
+pod on the branch, not just the one being worked on.
+
 Mounted paths
 -------------
 
@@ -125,8 +132,18 @@ the path changes with it. To find the prefix of a running frontend:
      -o jsonpath='{range .spec.containers[*].env[*]}{.name}={.value}{"\n"}{end}' \
      | grep -i prefix
 
-Sites upgrade independently, so a worker may need ``--path`` overridden via
-``RUN_ARG`` until its frontend is upgraded.
+``--path`` defaults to the **v3** endpoint. Web app instances upgrade
+independently, so a pod still connecting to a v2 web app overrides it in
+``RUN_ARG``:
+
+.. code-block:: yaml
+
+   RUN_ARG: rubintv_worker.py -a rubintv -p 8080 -l usdf --path /ws/worker
+
+At USDF as of August 2026 the dev instance runs the v3 web app (and so takes
+the default) while prod still runs v2 (and so carries the override). Confirm
+before relying on this — check the frontend's image tag, or GET
+``<prefix>/api/subapps``, which only the v3 app serves.
 
 The message contract is unchanged between v2 and v3: opaque text frames, one
 request and one response per job. Only the path moved.

--- a/doc/lsst.rubintv.analysis.service/deployment.rst
+++ b/doc/lsst.rubintv.analysis.service/deployment.rst
@@ -1,0 +1,199 @@
+.. _rubintv_analysis_service-deployment:
+
+=========================================
+Deployment of rubintv_analysis_service
+=========================================
+
+.. contents:: Table of Contents
+   :depth: 2
+
+Overview
+========
+
+This service runs as a **worker pod** in a Kubernetes cluster. It is not a
+server: nothing binds a port and nothing connects *to* it. The worker opens an
+**outbound websocket** to the RubinTV web app, waits for job messages, executes
+them, and sends results back over the same connection.
+
+Because the connection is outbound, a worker that cannot reach the web app has
+nothing to do and simply stops. See `Failure modes`_ for why that matters.
+
+Where it runs
+=============
+
+The service is deployed at three sites plus a development configuration. The
+site is chosen with ``--location`` and its settings come from
+``scripts/config.yaml``:
+
+==========  =============================================  ==========
+Location    ConsDB host                                    Butler
+==========  =============================================  ==========
+``summit``  postgresdb01.cp.lsst.org                       embargo
+``base``    postgresdb01.ls.lsst.org                       LSSTCam
+``usdf``    usdf-summitdb-replica.slac.stanford.edu        embargo
+``dev``     usdf-summitdb-replica.slac.stanford.edu        embargo
+==========  =============================================  ==========
+
+At USDF the pod lives in the ``rubintv`` namespace, alongside the RubinTV
+frontend and a Redis instance:
+
+.. code-block:: text
+
+   rubintv-frontend-...    the RubinTV web app this worker connects to
+   rubintv-redis-0         used by the web app, not by this service
+   rubintv-workers-...     this service
+
+The deployment is *not* defined in this repository. It is a Helm chart managed
+by Argo CD; the pod spec, image, and environment live there. Note that
+searching Phalanx for this service may not find it — check the ``rubintv``
+namespace's chart directly.
+
+How the pod is assembled
+========================
+
+The container image is `rubintv_production
+<https://github.com/lsst-sitcom/rubintv_production>`_ (tagged with a weekly
+science-pipelines build, e.g. ``w_2025_38``). That image is a **generic worker
+shell**, not specific to this service: it provides the LSST stack and a
+launcher that clones repositories at startup and runs whatever it is told to.
+
+This service is one payload that shell can run. Two environment variables
+select it:
+
+.. code-block:: yaml
+
+   SCRIPTS_LOCATION: /repos/rubintv_analysis_service/scripts
+   RUN_ARG: rubintv_worker.py -a rubintv -p 8080 -l usdf
+
+**The code is not baked into the image.** At every container start the launcher
+clones this repository fresh:
+
+.. code-block:: yaml
+
+   RA_PULL_DIRECTORIES: rubintv_analysis_service
+   DEPLOY_BRANCH: deploy-slac
+
+This has an important consequence: **deploying a change means pushing to the
+site's deploy branch**, not rebuilding an image. The pod picks it up on its
+next restart. The deploy branches are:
+
+- ``deploy-slac`` — USDF
+- ``deploy-summit`` — summit
+- ``deploy-bts`` — base test stand
+
+Mounted paths
+-------------
+
+The pod supplies configuration and credentials by volume mount, which is why
+``config.yaml`` refers to absolute paths that do not exist on a laptop:
+
+=========================================  ==============================
+Path                                       Contents
+=========================================  ==============================
+``/etc/secrets/``                          Postgres and AWS credentials,
+                                           assembled by an init container
+``/var/ddv-config``                        DDV user configuration
+``/sdf/group/rubin``, ``/sdf/data/rubin``  Shared Rubin filesystems
+=========================================  ==============================
+
+``$SDM_SCHEMAS_DIR`` must also be set; the worker reads the ConsDB schema YAML
+files from ``$SDM_SCHEMAS_DIR/yml`` at startup.
+
+Connecting to the web app
+=========================
+
+The worker connects to ``ws://<address>:<port><path>``, set by ``--address``,
+``--port`` and ``--path``.
+
+**The endpoint path depends on which version of the web app a site runs**, so
+it is a command-line option rather than a hardcoded value:
+
+=================  ==================================  ================================
+Web app            Worker endpoint                     Repository
+=================  ==================================  ================================
+v3 (current)       ``/rubintv/internal/ddv/worker``    `rubintv-v3 <https://github.com/lsst-ts/rubintv-v3>`_
+v2 (legacy)        ``/ws/worker``                      lsst-ts/rubintv
+=================  ==================================  ================================
+
+The v3 path is built from the app's configured prefix (``SAFIR_PATH_PREFIX``,
+``/rubintv`` at USDF) plus ``/internal/ddv/worker``. If a site's prefix differs,
+the path changes with it. To find the prefix of a running frontend:
+
+.. code-block:: bash
+
+   kubectl get pod <frontend-pod> -n rubintv \
+     -o jsonpath='{range .spec.containers[*].env[*]}{.name}={.value}{"\n"}{end}' \
+     | grep -i prefix
+
+Sites upgrade independently, so a worker may need ``--path`` overridden via
+``RUN_ARG`` until its frontend is upgraded.
+
+The message contract is unchanged between v2 and v3: opaque text frames, one
+request and one response per job. Only the path moved.
+
+Failure modes
+=============
+
+A worker that cannot connect exits **1** with a ``WorkerConnectionError``. This
+is deliberate: under the pod's ``restartPolicy: Always`` a zero exit is
+indistinguishable from a clean shutdown, so a misconfigured worker would
+restart silently and forever rather than surfacing as a failure.
+
+Diagnosing a worker pod
+-----------------------
+
+A worker in ``CrashLoopBackOff`` usually cannot be ``exec``'d into, but its
+logs and spec are still available:
+
+.. code-block:: bash
+
+   kubectl logs <worker-pod> -n rubintv --previous
+   kubectl get pod <worker-pod> -n rubintv -o yaml
+
+Check ``lastState.terminated.exitCode`` first — it separates the categories
+below.
+
+**Handshake status 403 Forbidden.** The endpoint path is wrong. FastAPI
+rejects an unmatched websocket route with 403 rather than 404, so this reads as
+an authentication failure but usually is not. Compare ``--path`` against the
+routes the frontend actually registers.
+
+**Could not find credentials for ...** No line in
+``/etc/secrets/postgres-credentials.txt`` matches both the site's ConsDB host
+and the ``--database`` name. Check the mounted secret and the host in
+``config.yaml``.
+
+**FileNotFoundError on a schema file.** ``$SDM_SCHEMAS_DIR`` is unset or the
+SDM schemas checkout is missing a file listed under ``schemas:`` in
+``config.yaml``. Note that an unset ``$SDM_SCHEMAS_DIR`` fails here rather than
+at startup, because the path is expanded without validation.
+
+**Butler connection errors, worker still running.** Butler failures are caught
+and logged rather than fatal, so the worker runs in a degraded state. This will
+not cause a restart loop.
+
+Verifying a fix
+---------------
+
+The frontend logs a ``ddv.worker.connected`` event when a worker successfully
+connects, which is the clearest confirmation that the endpoint and path are
+right:
+
+.. code-block:: bash
+
+   kubectl logs <frontend-pod> -n rubintv | grep ddv.worker
+
+Running locally
+===============
+
+``scripts/mock_server.py`` stands in for the web app so the worker can be run
+without a deployment:
+
+.. code-block:: bash
+
+   python scripts/mock_server.py                    # terminal 1
+   python scripts/rubintv_worker.py -l dev          # terminal 2
+
+The ``dev`` location expects credentials at ``~/.lsst/postgres-credentials.txt``
+rather than the mounted secret path, and ``$SDM_SCHEMAS_DIR`` must point at an
+SDM schemas checkout.

--- a/doc/lsst.rubintv.analysis.service/index.rst
+++ b/doc/lsst.rubintv.analysis.service/index.rst
@@ -20,6 +20,7 @@ toctree linking to topics related to using the module's APIs.
    :maxdepth: 2
 
    design
+   deployment
 
 .. _lsst.rubintv.analysis.service-contributing:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
 test = [
     "pytest >= 3.2",
     "flake8 >= 3.7.5",
-    "pytest-flake8 >= 1.0.4",
 ]
 
 [tool.setuptools.packages.find]

--- a/python/lsst/rubintv/analysis/service/worker.py
+++ b/python/lsst/rubintv/analysis/service/worker.py
@@ -32,6 +32,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("lsst.rubintv.analysis.service.client")
 
+# Path of the worker endpoint on the rubinTV web app. The v3 web app serves
+# this under its own path prefix (``/rubintv/internal/ddv/worker``); the v2
+# app served it unprefixed at ``/ws/worker``. Sites upgrade independently, so
+# this is overridable from the command line rather than fixed per branch.
+DEFAULT_WS_PATH = "/rubintv/internal/ddv/worker"
+
+
+class WorkerConnectionError(RuntimeError):
+    """The worker could not establish a usable connection to rubinTV.
+
+    Raised for failures that will not resolve by retrying, so that the
+    process can exit non-zero instead of looking like a clean shutdown.
+    """
+
 
 class Worker:
     """A worker that connects to the rubinTV server and executes commands.
@@ -42,26 +56,37 @@ class Worker:
         Address of the rubinTV web app websockets.
     _port :
         Port of the rubinTV web app websockets.
+    _path :
+        Path of the rubinTV worker websocket endpoint.
     _dataCenter :
         Data center for the worker.
     """
 
     _address: str
     _port: int
+    _path: str
     _data_center: DataCenter
+    _error: Exception | None
 
-    def __init__(self, address: str, port: int, data_center: DataCenter):
+    def __init__(self, address: str, port: int, data_center: DataCenter, path: str = DEFAULT_WS_PATH):
         self._address = address
         self._port = port
+        self._path = path if path.startswith("/") else f"/{path}"
         self._data_center = data_center
+        self._error = None
 
     @property
     def data_center(self) -> DataCenter:
         return self._data_center
 
-    def on_error(self, ws: WebSocketApp, error: str) -> None:
-        """Error received from the server."""
+    def on_error(self, ws: WebSocketApp, error: Exception) -> None:
+        """Error received from the server.
+
+        ``run_forever`` reports errors here and then returns normally, so the
+        error is recorded for ``run`` to act on once it has.
+        """
         logger.error(f"Error: {error}")
+        self._error = error
 
     def on_close(self, ws: WebSocketApp, close_status_code: str, close_msg: str) -> None:
         """Connection closed by the server."""
@@ -85,14 +110,24 @@ class Worker:
             response = execute_command(message, self.data_center)
             ws.send(response)
 
-        logger.connection(f"Connecting to rubinTV at {self._address}:{self._port}")
+        url = f"ws://{self._address}:{self._port}{self._path}"
+        logger.connection(f"Connecting to rubinTV at {url}")
 
         # Connect to the WebSocket server
+        self._error = None
         ws = WebSocketApp(
-            f"ws://{self._address}:{self._port}/ws/worker",
+            url,
             on_message=on_message,
             on_error=self.on_error,
             on_close=self.on_close,
         )
         ws.run_forever()
         ws.close()
+
+        # run_forever returns rather than raising when it cannot connect, so
+        # without this a worker that never reached the server would exit 0 and
+        # be indistinguishable from a clean shutdown. Under a Kubernetes
+        # restartPolicy that means a silent restart loop instead of a visible
+        # failure.
+        if self._error is not None:
+            raise WorkerConnectionError(f"Connection to {url} failed: {self._error}") from self._error

--- a/scripts/rubintv_worker.py
+++ b/scripts/rubintv_worker.py
@@ -32,7 +32,7 @@ from lsst.rubintv.analysis.service.data import DataCenter, DataMatch
 from lsst.rubintv.analysis.service.database import ConsDbSchema
 from lsst.rubintv.analysis.service.efd import EfdClient
 from lsst.rubintv.analysis.service.utils import ServerFormatter
-from lsst.rubintv.analysis.service.worker import Worker
+from lsst.rubintv.analysis.service.worker import DEFAULT_WS_PATH, Worker
 
 default_config = os.path.join(pathlib.Path(__file__).parent.absolute(), "config.yaml")
 default_joins = os.path.join(pathlib.Path(__file__).parent.absolute(), "joins.yaml")
@@ -95,6 +95,14 @@ def main():
     )
     parser.add_argument(
         "-p", "--port", default=8080, type=int, help="Port of the rubinTV web app websockets."
+    )
+    parser.add_argument(
+        "--path",
+        default=DEFAULT_WS_PATH,
+        type=str,
+        help="Path of the worker websocket endpoint on the rubinTV web app. "
+        f"Defaults to '{DEFAULT_WS_PATH}' (the v3 web app); sites still running "
+        "the v2 web app need '/ws/worker'.",
     )
     parser.add_argument(
         "-c", "--config", default=default_config, type=str, help="Location of the configuration file."
@@ -211,7 +219,7 @@ def main():
 
     # Run the client and connect to rubinTV via websockets
     logger.info("Initializing worker")
-    worker = Worker(args.address, args.port, data_center)
+    worker = Worker(args.address, args.port, data_center, path=args.path)
     worker.run()
 
 

--- a/scripts/update_deploy_branches.sh
+++ b/scripts/update_deploy_branches.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Bring the deployment branches up to date with main.
+#
+# Each site's worker pod clones its deploy branch fresh at every container
+# start, so merging main into a deploy branch *is* the deployment for that
+# site. See doc/lsst.rubintv.analysis.service/deployment.rst.
+#
+# Usage:
+#   scripts/update_deploy_branches.sh                  # dry run, all sites
+#   scripts/update_deploy_branches.sh --push           # merge and push
+#   scripts/update_deploy_branches.sh --push deploy-slac
+#
+# The default is a dry run: it reports what each branch would gain and exits
+# without changing anything.
+
+set -euo pipefail
+
+# The live deployment branches. Note that origin also carries deploy-usdf and
+# deploy-slac-comcam, which are stale predecessors and deliberately excluded —
+# updating them would suggest they are deployed when they are not.
+ALL_BRANCHES=(deploy-slac deploy-summit deploy-bts)
+
+SOURCE_BRANCH="main"
+REMOTE="origin"
+
+push=false
+branches=()
+
+for arg in "$@"; do
+    case "$arg" in
+        --push) push=true ;;
+        --help|-h) grep -m1 -B99 '^$' "$0" | tail -n +3 | cut -c3-; exit 0 ;;
+        -*) echo "unknown option: $arg" >&2; exit 2 ;;
+        *) branches+=("$arg") ;;
+    esac
+done
+
+if [ ${#branches[@]} -eq 0 ]; then
+    branches=("${ALL_BRANCHES[@]}")
+fi
+
+# Refuse to run with local modifications: the script switches branches, and
+# uncommitted work would either block the checkout or be carried onto a deploy
+# branch by accident.
+if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+    echo "error: working tree has uncommitted changes; commit or stash first" >&2
+    exit 1
+fi
+
+starting_branch=$(git rev-parse --abbrev-ref HEAD)
+restore() { git checkout --quiet "$starting_branch" 2>/dev/null || true; }
+trap restore EXIT
+
+echo "Fetching $REMOTE..."
+git fetch --quiet "$REMOTE"
+
+$push || echo "(dry run — pass --push to actually merge and push)"
+echo
+
+failed=()
+
+for branch in "${branches[@]}"; do
+    if ! git rev-parse --verify --quiet "$REMOTE/$branch" >/dev/null; then
+        echo "$branch: no such branch on $REMOTE — skipping"
+        failed+=("$branch")
+        echo
+        continue
+    fi
+
+    incoming=$(git rev-list --count "$REMOTE/$branch..$REMOTE/$SOURCE_BRANCH")
+    site_only=$(git rev-list --count "$REMOTE/$SOURCE_BRANCH..$REMOTE/$branch")
+
+    echo "$branch: $incoming commit(s) to take from $SOURCE_BRANCH, $site_only site-only commit(s)"
+
+    if [ "$incoming" -eq 0 ]; then
+        echo "  already up to date"
+        echo
+        continue
+    fi
+
+    git log --oneline "$REMOTE/$branch..$REMOTE/$SOURCE_BRANCH" | sed 's/^/    /'
+
+    if ! $push; then
+        echo
+        continue
+    fi
+
+    # Merge rather than rebase. Deploy branches are published and pulled by
+    # running pods, so rewriting their history would leave a pod that cloned
+    # mid-update on a commit that no longer exists.
+    git checkout --quiet "$branch"
+    git merge --quiet --ff-only "$REMOTE/$branch" 2>/dev/null || true
+
+    if git merge --no-edit "$REMOTE/$SOURCE_BRANCH" >/dev/null 2>&1; then
+        git push --quiet "$REMOTE" "$branch"
+        echo "  merged and pushed"
+    else
+        # Leave the conflict in place on the branch for the operator to
+        # resolve; continuing to the next site would hide it.
+        echo "  CONFLICT — resolve on '$branch', then: git push $REMOTE $branch" >&2
+        failed+=("$branch")
+        trap - EXIT
+        exit 1
+    fi
+    echo
+done
+
+if [ ${#failed[@]} -gt 0 ]; then
+    echo "completed with problems: ${failed[*]}" >&2
+    exit 1
+fi

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
+import shutil
 import sqlite3
 import tempfile
 from unittest import TestCase
@@ -31,6 +32,7 @@ from astropy.table import Table as ApTable
 from astropy.time import Time
 from lsst.rubintv.analysis.service.data import DataCenter
 from lsst.rubintv.analysis.service.database import ConsDbSchema
+from lsst.rubintv.analysis.service.logging import cleanup_persistent_logger
 
 # Convert visit DB datatypes to sqlite3 datatypes
 datatype_transform = {
@@ -217,9 +219,20 @@ class RasTestCase(TestCase):
         with open(joins_path) as file:
             joins = yaml.safe_load(file)["joins"]
 
-        # Create the datacenter
+        # Create the datacenter. The user path is a temporary directory so the
+        # query log a test triggers is written there rather than into the
+        # working directory.
+        self.user_dir = tempfile.mkdtemp()
         self.database = ConsDbSchema(schema=schema, engine=engine, join_templates=joins)
-        self.data_center = DataCenter(schemas={"testdb": self.database}, user_path="")
+        self.data_center = DataCenter(schemas={"testdb": self.database}, user_path=self.user_dir)
+
+        # The query logger opens its file lazily, part way through whichever
+        # test first logs a query. Closing it here as well as in tearDown keeps
+        # that handle from outliving the test that opened it: --open-files
+        # compares the open files at teardown against those at setup, and its
+        # teardown hook runs before unittest's own tearDown has finished.
+        self.addCleanup(cleanup_persistent_logger)
+        cleanup_persistent_logger()
 
     def tearDown(self) -> None:
         # Clean up database connection
@@ -230,9 +243,9 @@ class RasTestCase(TestCase):
         os.remove(self.db_file.name)
 
         # Clean up any persistent loggers
-        from lsst.rubintv.analysis.service.logging import cleanup_persistent_logger
-
         cleanup_persistent_logger()
+
+        shutil.rmtree(self.user_dir, ignore_errors=True)
 
     def assertDataTableEqual(self, result: dict | ApTable, truth: ApTable):  # NOQA: N802
         """Check if two data tables are equal.


### PR DESCRIPTION
Adds a `path` argument to the worker script that allows for per location tuning of the websocket endpoint from RubinTV and sets the default to that used by RubinTV v3.

Also adds deployment docs and a script to automate bringing individual deployment branches to match `main`.

Also fixes a couple of bugs in the test suite - removes outdated `pytest-flake8` and closes the queries log file after testing.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
