### PR TITLE
Pin setuptools below 81 for the docs build

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -27,7 +27,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install wheel
-          pip install --upgrade setuptools
+          # setuptools 81 removed pkg_resources, which
+          # lsst_sphinx_bootstrap_theme (pulled in by documenteer) imports at
+          # module scope. Pinned below that until the theme is updated.
+          pip install --upgrade 'setuptools<81'
 
       - name: Build and install
         run: pip install -v -e .


### PR DESCRIPTION
setuptools 81 removed pkg_resources, which lsst_sphinx_bootstrap_theme imports at module scope. The theme is pulled in by documenteer, so the docs build fails while Sphinx evaluates conf.py, before it reads any source file:

    File ".../lsst_sphinx_bootstrap_theme/__init__.py", line 2
      import pkg_resources
  ModuleNotFoundError: No module named 'pkg_resources'

The workflow upgrades setuptools unconditionally, so this began failing on its own: the last green docs run was in November 2025 and nothing in the repository changed. Pin below 81 until the theme stops using pkg_resources, at which point the pin can be dropped.

Verified in a clean venv following the workflow's steps: setuptools 84.0.0 reproduces the failure, and with the pin `package-docs build` completes.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
